### PR TITLE
add src url to video stream

### DIFF
--- a/attachmediastream.js
+++ b/attachmediastream.js
@@ -39,5 +39,6 @@ module.exports = function (stream, el, options) {
     }
 
     element.srcObject = stream;
+    element.src = URL.createObjectURL(stream);
     return element;
 };


### PR DESCRIPTION
Add stream url to src tag for support other browsers.
I had problem with work EasyWebRTC and Cordova application (iOS + cordova-plugin-iosrtc) using WebRTC.