### PR TITLE
bugfix in case of no video element for Safari

### DIFF
--- a/attachmediastream.js
+++ b/attachmediastream.js
@@ -39,7 +39,7 @@ module.exports = function (stream, el, options) {
     }
 
     if (adapter.browserDetails.browser === 'safari') {
-        el.playsinline = true;
+        element.playsinline = true;
     }
 
     element.srcObject = stream;


### PR DESCRIPTION
In Safari 11, when there is no `<video>` element initially, `el.playsinline = true;` cause error. 